### PR TITLE
Allow double-quoted import statements in URL handler

### DIFF
--- a/examples/url/main.tsx
+++ b/examples/url/main.tsx
@@ -1,4 +1,4 @@
-import React from 'https://esm.sh/react@18.2.0';
+import React from "https://esm.sh/react@18.2.0";
 import { createRoot } from 'https://esm.sh/react-dom@18.2.0/client';
 import { App } from './local.tsx';
 import './style.css';

--- a/src/url-resolve.ts
+++ b/src/url-resolve.ts
@@ -47,6 +47,7 @@ export default function httpsResolve(config: PluginConfig) {
 
     transform(code: string) {
       if (code.indexOf('from \'http') === -1) {
+      if (code.indexOf('from \'http') === -1 && code.indexOf('from \"http') === -1) {
         return;
       }
 
@@ -55,7 +56,11 @@ export default function httpsResolve(config: PluginConfig) {
       const replaced = code.replaceAll(
         HTTP_IMPORT_REGEX,
         (str) => {
-          return str.replace('from \'', 'from \'' + URL_NAMESPACE);
+          console.log(`HTTP Detected`, str)
+          const replaced = str
+            .replace('from \'', 'from \'' + URL_NAMESPACE)
+            .replace('from \"', 'from \"' + URL_NAMESPACE);
+          return replaced;
         },
       );
 

--- a/src/url-resolve.ts
+++ b/src/url-resolve.ts
@@ -56,11 +56,9 @@ export default function httpsResolve(config: PluginConfig) {
       const replaced = code.replaceAll(
         HTTP_IMPORT_REGEX,
         (str) => {
-          console.log(`HTTP Detected`, str)
-          const replaced = str
+          return str
             .replace('from \'', 'from \'' + URL_NAMESPACE)
             .replace('from \"', 'from \"' + URL_NAMESPACE);
-          return replaced;
         },
       );
 

--- a/src/url-resolve.ts
+++ b/src/url-resolve.ts
@@ -46,7 +46,6 @@ export default function httpsResolve(config: PluginConfig) {
     enforce: 'pre' as const,
 
     transform(code: string) {
-      if (code.indexOf('from \'http') === -1) {
       if (code.indexOf('from \'http') === -1 && code.indexOf('from \"http') === -1) {
         return;
       }


### PR DESCRIPTION
Fixes issue #7

The main bug was the code exiting early inside the transform function where there were valid import statements.

It's a fairly crude fix, just duplicating the lines to perform the same tasks for single strings.